### PR TITLE
Accumulator Actor + RPC + Proxy methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2705,6 +2705,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "fendermint_actor_accumulator"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fil_actors_runtime",
+ "frc42_dispatch",
+ "fvm_ipld_amt",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_shared",
+ "multihash 0.18.1",
+ "num-derive 0.3.3",
+ "num-traits",
+ "serde",
+ "serde_tuple",
+]
+
+[[package]]
 name = "fendermint_actor_chainmetadata"
 version = "0.1.0"
 dependencies = [
@@ -2746,6 +2765,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cid",
+ "fendermint_actor_accumulator",
  "fendermint_actor_chainmetadata",
  "fendermint_actor_objectstore",
  "fil_actor_bundler",
@@ -3127,6 +3147,7 @@ dependencies = [
  "async-trait",
  "cid",
  "ethers",
+ "fendermint_actor_accumulator",
  "fendermint_actor_chainmetadata",
  "fendermint_actor_objectstore",
  "fendermint_actors",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2992,6 +2992,7 @@ dependencies = [
  "cid",
  "clap 4.4.14",
  "ethers",
+ "fendermint_actor_accumulator",
  "fendermint_actor_objectstore",
  "fendermint_crypto",
  "fendermint_vm_actor_interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
   "fendermint/actors",
   "fendermint/actors/chainmetadata",
   "fendermint/actors/objectstore",
+  "fendermint/actors/accumulator",
 ]
 
 [workspace.package]

--- a/fendermint/actors/Cargo.toml
+++ b/fendermint/actors/Cargo.toml
@@ -12,6 +12,9 @@ fendermint_actor_chainmetadata = { path = "chainmetadata", features = [
 fendermint_actor_objectstore = { path = "objectstore", features = [
     "fil-actor",
 ] }
+fendermint_actor_accumulator = { path = "accumulator", features = [
+    "fil-actor",
+] }
 
 [dependencies]
 cid = { workspace = true }
@@ -20,6 +23,7 @@ fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fendermint_actor_chainmetadata = { path = "chainmetadata" }
 fendermint_actor_objectstore = { path = "objectstore" }
+fendermint_actor_accumulator = { path = "accumulator" }
 
 [build-dependencies]
 fil_actors_runtime = { workspace = true, features = ["test_utils"] }

--- a/fendermint/actors/accumulator/Cargo.toml
+++ b/fendermint/actors/accumulator/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "fendermint_actor_accumulator"
+description = "Actor for event accumulation"
+license.workspace = true
+edition.workspace = true
+authors.workspace = true
+version = "0.1.0"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[dependencies]
+cid = { workspace = true, default-features = false }
+fil_actors_runtime = { workspace = true, optional = true, features = [
+    "fil-actor",
+] }
+multihash = { workspace = true }
+fvm_shared = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
+fvm_ipld_blockstore = { workspace = true }
+fvm_ipld_amt = { workspace = true }
+num-derive = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_tuple = { workspace = true }
+num-traits = { workspace = true }
+frc42_dispatch = { workspace = true }
+anyhow = { workspace = true }
+
+[dev-dependencies]
+fil_actors_runtime = { workspace = true, features = [
+    "test_utils",
+    "fil-actor",
+] }
+
+[features]
+default = []
+fil-actor = ["fil_actors_runtime"]

--- a/fendermint/actors/accumulator/src/actor.rs
+++ b/fendermint/actors/accumulator/src/actor.rs
@@ -2,13 +2,15 @@
 // Copyright 2021-2023 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use cid::Cid;
 use fil_actors_runtime::actor_dispatch;
 use fil_actors_runtime::actor_error;
 use fil_actors_runtime::builtin::singletons::SYSTEM_ACTOR_ADDR;
 use fil_actors_runtime::runtime::{ActorCode, Runtime};
 use fil_actors_runtime::ActorDowncast;
 use fil_actors_runtime::ActorError;
-use fvm_ipld_hamt::BytesKey;
+// use fvm_ipld_encoding::de::DeserializeOwned;
+// use fvm_ipld_encoding::ser::Serialize;
 use fvm_shared::error::ExitCode;
 
 use crate::{Method, State, ACCUMULATOR_ACTOR_NAME};
@@ -32,7 +34,7 @@ impl Actor {
         rt.create(&state)
     }
 
-    fn push<S: DeserializeOwned + Serialize>(rt: &impl Runtime, obj: S) -> Result<Cid, ActorError> {
+    fn push(rt: &impl Runtime, obj: Vec<u8>) -> Result<Cid, ActorError> {
         // FIXME:(carsonfarmer) We'll want to validate the caller is the owner of the repo.
         rt.validate_immediate_caller_accept_any()?;
 
@@ -45,31 +47,30 @@ impl Actor {
 
     fn get_root(rt: &impl Runtime) -> Result<Cid, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
-        rt.state().map(|st| {
-            st.get_root(rt.store())
-                .map_err(|e| e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to bag peaks"))
-        })
+        let st: State = rt.state()?;
+        st.get_root(rt.store())
+            .map_err(|e| e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to bag peaks"))
     }
 
     fn get_peaks(rt: &impl Runtime) -> Result<Vec<Cid>, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
-        rt.state().map(|st| {
-            st.get_peaks(rt.store())
-                .map_err(|e| e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to get peaks"))
-        })
+        let st: State = rt.state()?;
+        st.get_peaks(rt.store())
+            .map_err(|e| e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to get peaks"))
     }
 
     fn get_count(rt: &impl Runtime) -> Result<u64, ActorError> {
         rt.validate_immediate_caller_accept_any()?;
-        rt.state().map(|st| st.leaf_count)
+        let st: State = rt.state()?;
+        Ok(st.leaf_count)
     }
 }
-
+// body filter on warp - 500kbs
 impl ActorCode for Actor {
     type Methods = Method;
 
     fn name() -> &'static str {
-        ACCUMULATOR_ACTOR_NAME_ACTOR_NAME
+        ACCUMULATOR_ACTOR_NAME
     }
 
     actor_dispatch! {

--- a/fendermint/actors/accumulator/src/actor.rs
+++ b/fendermint/actors/accumulator/src/actor.rs
@@ -46,6 +46,11 @@ impl Actor {
         Ok(())
     }
 
+    fn get_count(rt: &impl Runtime) -> Result<u64, ActorError> {
+        let st: State = rt.state()?;
+        Ok(st.leaf_count)
+    }
+
     fn get_peaks(rt: &impl Runtime) -> Result<Vec<Cid>, ActorError> {
         let st: State = rt.state()?;
         st.get_peaks(rt.store())

--- a/fendermint/actors/accumulator/src/actor.rs
+++ b/fendermint/actors/accumulator/src/actor.rs
@@ -1,0 +1,77 @@
+// Copyright 2024 Textile Inc
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use fil_actors_runtime::actor_dispatch;
+use fil_actors_runtime::actor_error;
+use fil_actors_runtime::builtin::singletons::SYSTEM_ACTOR_ADDR;
+use fil_actors_runtime::runtime::{ActorCode, Runtime};
+use fil_actors_runtime::ActorDowncast;
+use fil_actors_runtime::ActorError;
+use fvm_ipld_hamt::BytesKey;
+use fvm_shared::error::ExitCode;
+
+use crate::{Method, PushParams, State, ACCUMULATOR_ACTOR_NAME};
+
+fil_actors_runtime::wasm_trampoline!(Actor);
+
+pub struct Actor;
+
+impl Actor {
+    fn constructor(rt: &impl Runtime) -> Result<(), ActorError> {
+        // FIXME:(carsonfarmer) We're setting this up to be a subnet-wide actor for a single repo.
+        // FIXME:(carsonfarmer) In the future, this could be deployed dynamically for multi repo subnets.
+        rt.validate_immediate_caller_is(std::iter::once(&SYSTEM_ACTOR_ADDR))?;
+
+        let state = State::new(rt.store()).map_err(|e| {
+            e.downcast_default(
+                ExitCode::USR_ILLEGAL_STATE,
+                "failed to construct empty store",
+            )
+        })?;
+
+        rt.create(&state)
+    }
+
+    fn push(rt: &impl Runtime, params: PushParams) -> Result<(), ActorError> {
+        // FIXME:(carsonfarmer) We'll want to validate the caller is the owner of the repo.
+        rt.validate_immediate_caller_accept_any()?;
+
+        rt.transaction(|st: &mut State, rt| {
+            st.push(rt.store(), params.obj).map_err(|e| {
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to put object")
+            })
+        })?;
+
+        Ok(())
+    }
+
+    fn get_peaks(rt: &impl Runtime) -> Result<Vec<Cid>, ActorError> {
+        let st: State = rt.state()?;
+        st.get_peaks(rt.store())
+            .map_err(|e| e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to get peaks"))
+    }
+
+    fn bag_peaks(rt: &impl Runtime) -> Result<Cid, ActorError> {
+        let st: State = rt.state()?;
+        st.bag_peaks(rt.store())
+            .map_err(|e| e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to bag peaks"))
+    }
+}
+
+impl ActorCode for Actor {
+    type Methods = Method;
+
+    fn name() -> &'static str {
+        OBJECTSTORE_ACTOR_NAME
+    }
+
+    actor_dispatch! {
+        Constructor => constructor,
+        PutObject => put_object,
+        AppendObject => append_object,
+        DeleteObject => delete_object,
+        GetObject => get_object,
+        ListObjects => list_objects,
+    }
+}

--- a/fendermint/actors/accumulator/src/actor.rs
+++ b/fendermint/actors/accumulator/src/actor.rs
@@ -40,7 +40,7 @@ impl Actor {
 
         rt.transaction(|st: &mut State, rt| {
             st.push(rt.store(), obj).map_err(|e| {
-                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to put object")
+                e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to push object")
             })
         })
     }
@@ -65,7 +65,7 @@ impl Actor {
         Ok(st.leaf_count)
     }
 }
-// body filter on warp - 500kbs
+
 impl ActorCode for Actor {
     type Methods = Method;
 

--- a/fendermint/actors/accumulator/src/actor.rs
+++ b/fendermint/actors/accumulator/src/actor.rs
@@ -44,10 +44,12 @@ impl Actor {
     }
 
     fn get_count(rt: &impl Runtime) -> Result<u64, ActorError> {
+        rt.validate_immediate_caller_accept_any()?;
         rt.state().map(|st| st.leaf_count)
     }
 
     fn get_peaks(rt: &impl Runtime) -> Result<Vec<Cid>, ActorError> {
+        rt.validate_immediate_caller_accept_any()?;
         rt.state().map(|st| {
             st.get_peaks(rt.store())
                 .map_err(|e| e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to get peaks"))
@@ -55,6 +57,7 @@ impl Actor {
     }
 
     fn bag_peaks(rt: &impl Runtime) -> Result<Cid, ActorError> {
+        rt.validate_immediate_caller_accept_any()?;
         rt.state().map(|st| {
             st.bag_peaks(rt.store())
                 .map_err(|e| e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to bag peaks"))

--- a/fendermint/actors/accumulator/src/lib.rs
+++ b/fendermint/actors/accumulator/src/lib.rs
@@ -1,0 +1,9 @@
+// Copyright 2024 Textile Inc
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+#[cfg(feature = "fil-actor")]
+mod actor;
+mod shared;
+
+pub use shared::*;

--- a/fendermint/actors/accumulator/src/shared.rs
+++ b/fendermint/actors/accumulator/src/shared.rs
@@ -110,6 +110,11 @@ impl State {
         bag_peaks(&amt)
     }
 
+    pub fn get_root<BS: Blockstore>(&self, store: &BS) -> anyhow::Result<Cid> {
+        let amt = Amt::<Cid, &BS>::load(&self.peaks, store)?;
+        bag_peaks(&amt)
+    }
+
     pub fn get_peaks<BS: Blockstore>(&self, store: &BS) -> anyhow::Result<Vec<Cid>> {
         let amt = Amt::<Cid, &BS>::load(&self.peaks, store)?;
         let mut peaks = Vec::new();
@@ -119,11 +124,6 @@ impl State {
         })?;
         Ok(peaks)
     }
-
-    pub fn bag_peaks<BS: Blockstore>(&self, store: &BS) -> anyhow::Result<Cid> {
-        let amt = Amt::<Cid, &BS>::load(&self.peaks, store)?;
-        bag_peaks(&amt)
-    }
 }
 
 pub const ACCUMULATOR_ACTOR_NAME: &str = "accumulator";
@@ -132,9 +132,10 @@ pub const ACCUMULATOR_ACTOR_NAME: &str = "accumulator";
 #[repr(u64)]
 pub enum Method {
     Constructor = METHOD_CONSTRUCTOR,
-    Append = frc42_dispatch::method_hash!("Append"),
-    GetRoot = frc42_dispatch::method_hash!("GetRoot"),
-    BagPeaks = frc42_dispatch::method_hash!("BagPeaks"),
+    Push = frc42_dispatch::method_hash!("Push"),
+    Root = frc42_dispatch::method_hash!("Root"),
+    Peaks = frc42_dispatch::method_hash!("Peaks"),
+    Count = frc42_dispatch::method_hash!("Count"),
 }
 
 #[cfg(test)]
@@ -201,7 +202,7 @@ mod tests {
         let peaks = state.get_peaks(&store).unwrap();
         assert_eq!(peaks.len(), 3);
         assert_eq!(state.leaf_count, 11);
-        let root = state.bag_peaks(&store);
+        let root = state.get_root(&store);
         assert!(root.is_ok());
         assert_eq!(
             root.unwrap(),

--- a/fendermint/actors/accumulator/src/shared.rs
+++ b/fendermint/actors/accumulator/src/shared.rs
@@ -1,0 +1,215 @@
+// Copyright 2024 Textile Inc
+// Copyright 2021-2023 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use cid::multihash::Code;
+use cid::multihash::MultihashDigest;
+use cid::Cid;
+use fvm_ipld_amt::Amt;
+use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_encoding::de::DeserializeOwned;
+use fvm_ipld_encoding::ser::Serialize;
+use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
+use fvm_ipld_encoding::CborStore;
+use fvm_ipld_encoding::{to_vec, DAG_CBOR};
+use fvm_shared::METHOD_CONSTRUCTOR;
+use num_derive::FromPrimitive;
+
+const BIT_WIDTH: u32 = 3;
+
+/// Compute the hash of a pair of CIDs.
+/// The hash is the CID of a new block containing the concatenation of the two CIDs.
+/// We do not include the index of the element(s) because incoming data should already be "nonced".
+fn hash_pair(left: Option<&Cid>, right: Option<&Cid>) -> anyhow::Result<Cid> {
+    if left.is_none() || right.is_none() {
+        return Err(anyhow::anyhow!("hash_pair requires two CIDs"));
+    }
+    // Encode the CIDs into a binary format
+    let data = to_vec(&[left, right])?;
+    // Compute the CID for the block
+    let mh_code = Code::Blake2b256;
+    let mh = mh_code.digest(&data);
+    let cid = Cid::new_v1(DAG_CBOR, mh);
+    Ok(cid)
+}
+
+/// Return the new peaks of the accumulator after adding `new_leaf`.
+fn push<BS: Blockstore>(
+    leaf_count: u64,
+    peaks: &mut Amt<Cid, &BS>,
+    leaf: Cid,
+) -> anyhow::Result<Cid> {
+    // Push the new leaf onto the peaks
+    peaks.set(peaks.count(), leaf)?;
+    // Count trailing ones in the binary representation of leaf_count + 1
+    // This works because adding a leaf fills the next available spot,
+    // and the binary representation of this index will have trailing ones
+    // where merges are required.
+    let mut new_peaks = (!leaf_count).trailing_zeros();
+    while new_peaks > 0 {
+        // Pop the last two peaks and push their hash
+        let right = peaks.delete(peaks.count() - 1)?;
+        let left = peaks.delete(peaks.count() - 1)?;
+        // Push the new peak onto the peaks array
+        peaks.set(peaks.count(), hash_pair(left.as_ref(), right.as_ref())?)?;
+        new_peaks -= 1;
+    }
+    Ok(peaks.flush()?)
+}
+
+/// Collect the peaks and combine to compute the root commitment.
+fn bag_peaks<BS: Blockstore>(peaks: &Amt<Cid, &BS>) -> anyhow::Result<Cid> {
+    let peaks_count = peaks.count();
+    if peaks_count == 0 {
+        return Ok(Cid::default());
+    }
+    if peaks_count == 1 {
+        return Ok(peaks.get(0)?.unwrap().to_owned());
+    }
+    let mut root = hash_pair(peaks.get(peaks_count - 2)?, peaks.get(peaks_count - 1)?)?;
+    for i in 2..peaks_count {
+        root = hash_pair(peaks.get(peaks_count - 1 - i)?, Some(&root))?;
+    }
+    Ok(root)
+}
+
+// The state represents an mmr with peaks stored in an Amt
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct State {
+    pub peaks: Cid,
+    pub leaf_count: u64,
+}
+
+impl State {
+    pub fn new<BS: Blockstore>(store: &BS) -> anyhow::Result<Self> {
+        let peaks = match Amt::<(), _>::new_with_bit_width(store, BIT_WIDTH).flush() {
+            Ok(cid) => cid,
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "accumulator actor failed to create empty Amt: {}",
+                    e
+                ))
+            }
+        };
+        Ok(Self {
+            peaks,
+            leaf_count: 0,
+        })
+    }
+
+    pub fn push<BS: Blockstore, S: DeserializeOwned + Serialize>(
+        &mut self,
+        store: &BS,
+        obj: S,
+    ) -> anyhow::Result<()> {
+        let mut amt = Amt::<Cid, &BS>::load(&self.peaks, store)?;
+        let leaf = store.put_cbor(&obj, Code::Blake2b256)?;
+        self.peaks = push(self.leaf_count, &mut amt, leaf)?;
+        self.leaf_count += 1;
+        Ok(())
+    }
+
+    pub fn get_peaks<BS: Blockstore>(&self, store: &BS) -> anyhow::Result<Vec<Cid>> {
+        let amt = Amt::<Cid, &BS>::load(&self.peaks, store)?;
+        let mut peaks = Vec::new();
+        amt.for_each(|_, cid| {
+            peaks.push(cid.to_owned());
+            Ok(())
+        })?;
+        Ok(peaks)
+    }
+
+    pub fn bag_peaks<BS: Blockstore>(&self, store: &BS) -> anyhow::Result<Cid> {
+        let amt = Amt::<Cid, &BS>::load(&self.peaks, store)?;
+        bag_peaks(&amt)
+    }
+}
+
+pub const ACCUMULATOR_ACTOR_NAME: &str = "accumulator";
+
+#[derive(Default, Debug, Serialize_tuple, Deserialize_tuple)]
+pub struct PushParams<O: DeserializeOwned + Serialize> {
+    pub obj: O,
+}
+
+#[derive(FromPrimitive)]
+#[repr(u64)]
+pub enum Method {
+    Constructor = METHOD_CONSTRUCTOR,
+    Append = frc42_dispatch::method_hash!("Append"),
+    GetRoot = frc42_dispatch::method_hash!("GetRoot"),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_constructor() {
+        let store = fvm_ipld_blockstore::MemoryBlockstore::default();
+        let state = State::new(&store);
+        assert!(state.is_ok());
+        let state = state.unwrap();
+        assert_eq!(
+            state.peaks,
+            Cid::from_str("bafy2bzacedijw74yui7otvo63nfl3hdq2vdzuy7wx2tnptwed6zml4vvz7wee")
+                .unwrap()
+        );
+        assert_eq!(state.leaf_count, 0);
+    }
+
+    #[test]
+    fn test_push_simple() {
+        let store = fvm_ipld_blockstore::MemoryBlockstore::default();
+        let mut state = State::new(&store).unwrap();
+        let params = PushParams { obj: vec![1, 2, 3] };
+        assert!(state.push(&store, params.obj).is_ok());
+        assert_eq!(state.leaf_count, 1);
+    }
+
+    #[test]
+    fn test_get_peaks() {
+        let store = fvm_ipld_blockstore::MemoryBlockstore::default();
+        let mut state = State::new(&store).unwrap();
+        let params = PushParams { obj: vec![1, 2, 3] };
+        assert!(state.push(&store, params.obj).is_ok());
+        assert_eq!(state.leaf_count, 1);
+        let peaks = state.get_peaks(&store);
+        assert!(peaks.is_ok());
+        let peaks = peaks.unwrap();
+        assert_eq!(peaks.len(), 1);
+        assert_eq!(
+            peaks[0],
+            Cid::from_str("bafy2bzacebltuz74cvzod3x7cx3eledj4gn5vjcer7znymoq56htf2e3cclok")
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_bag_peaks() {
+        let store = fvm_ipld_blockstore::MemoryBlockstore::default();
+        let mut state = State::new(&store).unwrap();
+        state.push(&store, vec![1]).unwrap();
+        state.push(&store, vec![2]).unwrap();
+        state.push(&store, vec![3]).unwrap();
+        state.push(&store, vec![4]).unwrap();
+        state.push(&store, vec![5]).unwrap();
+        state.push(&store, vec![6]).unwrap();
+        state.push(&store, vec![7]).unwrap();
+        state.push(&store, vec![8]).unwrap();
+        state.push(&store, vec![9]).unwrap();
+        state.push(&store, vec![10]).unwrap();
+        state.push(&store, vec![11]).unwrap();
+        let peaks = state.get_peaks(&store).unwrap();
+        assert_eq!(peaks.len(), 3);
+        assert_eq!(state.leaf_count, 11);
+        let root = state.bag_peaks(&store);
+        assert!(root.is_ok());
+        assert_eq!(
+            root.unwrap(),
+            Cid::from_str("bafy2bzaced4l2dtp5op3owgzivgs2q2lwk2edijcf57vn2wxllqbhko35wnse")
+                .unwrap()
+        );
+    }
+}

--- a/fendermint/actors/accumulator/src/shared.rs
+++ b/fendermint/actors/accumulator/src/shared.rs
@@ -106,7 +106,8 @@ impl State {
         let leaf = store.put_cbor(&obj, Code::Blake2b256)?;
         self.peaks = push(self.leaf_count, &mut amt, leaf)?;
         self.leaf_count += 1;
-        bag_peaks(&amt) // TODO(carsonfarmer): Maybe we just want to return the root of the Amt?
+        // TODO:(carsonfarmer) Maybe we just want to return the root of the Amt?
+        bag_peaks(&amt)
     }
 
     pub fn get_peaks<BS: Blockstore>(&self, store: &BS) -> anyhow::Result<Vec<Cid>> {

--- a/fendermint/actors/build.rs
+++ b/fendermint/actors/build.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use std::thread;
 
-const ACTORS: &[&str] = &["chainmetadata", "objectstore"];
+const ACTORS: &[&str] = &["chainmetadata", "objectstore", "accumulator"];
 
 const FILES_TO_WATCH: &[&str] = &["Cargo.toml", "src", "actors"];
 

--- a/fendermint/actors/objectstore/src/shared.rs
+++ b/fendermint/actors/objectstore/src/shared.rs
@@ -57,7 +57,6 @@ impl State {
         content: Vec<u8>,
     ) -> anyhow::Result<Cid> {
         let mut hamt = Hamt::<_, Vec<u8>>::load_with_bit_width(&self.root, store, BIT_WIDTH)?;
-
         let new_content = match hamt.get(&key)? {
             Some(existing) => {
                 let mut new_content = existing.clone();
@@ -66,7 +65,6 @@ impl State {
             }
             None => content,
         };
-
         hamt.set(key, new_content)?;
         self.root = hamt.flush()?;
         Ok(self.root)

--- a/fendermint/actors/objectstore/src/shared.rs
+++ b/fendermint/actors/objectstore/src/shared.rs
@@ -72,9 +72,12 @@ impl State {
 
     pub fn delete<BS: Blockstore>(&mut self, store: &BS, key: &BytesKey) -> anyhow::Result<Cid> {
         let mut hamt = Hamt::<_, Vec<u8>>::load_with_bit_width(&self.root, store, BIT_WIDTH)?;
-        hamt.delete(key)?;
-        self.root = hamt.flush()?;
-        Ok(self.root)
+        if hamt.contains_key(key)? {
+            hamt.delete(key)?;
+            self.root = hamt.flush()?;
+            return Ok(self.root);
+        }
+        return Err(anyhow::anyhow!("key not found"));
     }
 
     pub fn get<BS: Blockstore>(
@@ -183,6 +186,14 @@ mod tests {
         let result = state.get(&store, &key);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), None);
+    }
+
+    #[test]
+    fn test_delete_missing() {
+        let store = fvm_ipld_blockstore::MemoryBlockstore::default();
+        let mut state = State::new(&store).unwrap();
+        let key = BytesKey("missing".as_bytes().to_vec());
+        assert!(state.delete(&store, &key).is_err());
     }
 
     #[test]

--- a/fendermint/actors/src/manifest.rs
+++ b/fendermint/actors/src/manifest.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use anyhow::{anyhow, Context};
 use cid::Cid;
+use fendermint_actor_accumulator::ACCUMULATOR_ACTOR_NAME;
 use fendermint_actor_chainmetadata::CHAINMETADATA_ACTOR_NAME;
 use fendermint_actor_objectstore::OBJECTSTORE_ACTOR_NAME;
 use fvm_ipld_blockstore::Blockstore;
@@ -9,7 +10,11 @@ use fvm_ipld_encoding::CborStore;
 use std::collections::HashMap;
 
 // array of required actors
-pub const REQUIRED_ACTORS: &[&str] = &[CHAINMETADATA_ACTOR_NAME, OBJECTSTORE_ACTOR_NAME];
+pub const REQUIRED_ACTORS: &[&str] = &[
+    CHAINMETADATA_ACTOR_NAME,
+    OBJECTSTORE_ACTOR_NAME,
+    ACCUMULATOR_ACTOR_NAME,
+];
 
 /// A mapping of internal actor CIDs to their respective types.
 pub struct Manifest {

--- a/fendermint/app/options/src/rpc.rs
+++ b/fendermint/app/options/src/rpc.rs
@@ -101,24 +101,31 @@ pub enum RpcQueryCommands {
     StateParams,
 }
 
+// FIXME:(carsonfarmer) For now, just adding all commands to the data repo enum.
+
 #[derive(Subcommand, Debug, Clone)]
 pub enum RpcDataRepoCommands {
+    // Object Store operations
+    /// Put a new key-value pair into the data repo.
     Put {
         #[arg(long, short)]
         key: String,
         #[arg(long, short)]
         content: Bytes,
     },
+    /// Append to an existing key in the data repo.
     Append {
         #[arg(long, short)]
         key: String,
         #[arg(long, short)]
         content: Bytes,
     },
+    /// Delete the value at a key from the data repo.
     Delete {
         #[arg(long, short)]
         key: String,
     },
+    /// Get the value of a key from the data repo.
     Get {
         #[arg(long, short)]
         key: String,
@@ -126,7 +133,21 @@ pub enum RpcDataRepoCommands {
         #[arg(long, short = 'b', default_value_t = 0)]
         height: u64,
     },
+    /// List all keys in the data repo.
     List {
+        /// Block height to query; 0 means latest.
+        #[arg(long, short = 'b', default_value_t = 0)]
+        height: u64,
+    },
+    // Accumulator operations
+    /// Push a new value into the data repo's accumulator.
+    Push {
+        /// Content to push into the data repo for tracking.
+        #[arg(long, short)]
+        content: Bytes,
+    },
+    /// Get the root commitment of the data repo's accumulator.
+    Root {
         /// Block height to query; 0 means latest.
         #[arg(long, short = 'b', default_value_t = 0)]
         height: u64,

--- a/fendermint/app/src/cmd/proxy.rs
+++ b/fendermint/app/src/cmd/proxy.rs
@@ -27,6 +27,7 @@ use tokio::sync::Mutex;
 use warp::{http::StatusCode, Filter, Rejection, Reply};
 
 const MAX_BODY_LENGTH: u64 = 1024 * 1024 * 1024;
+const MAX_EVENT_LENGTH: u64 = 1024 * 500; // Limit to 500KiB for now
 
 cmd! {
     ProxyArgs(self) {
@@ -70,7 +71,7 @@ cmd! {
                 // Accumulator routes
                 let push_route = warp::path!("v1" / "acc")
                     .and(warp::put())
-                    .and(warp::body::content_length_limit(MAX_BODY_LENGTH))
+                    .and(warp::body::content_length_limit(MAX_EVENT_LENGTH))
                     .and(with_client(client.clone()))
                     .and(with_args(args.clone()))
                     .and(with_nonce(nonce))

--- a/fendermint/app/src/cmd/proxy.rs
+++ b/fendermint/app/src/cmd/proxy.rs
@@ -17,6 +17,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::BLOCK_GAS_LIMIT;
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -288,7 +289,8 @@ async fn handle_root(
             })
         })?;
 
-    Ok(warp::reply::html(res.unwrap_or_default().to_string()))
+    let json = json!({"repo_root": res.unwrap_or_default().to_string()});
+    Ok(warp::reply::json(&json))
 }
 
 #[derive(Clone, Debug)]

--- a/fendermint/app/src/cmd/rpc.rs
+++ b/fendermint/app/src/cmd/rpc.rs
@@ -76,6 +76,13 @@ cmd! {
                     let height = Height::try_from(height)?;
                     datarepo_list_call(client, args, height).await
                 }
+                RpcDataRepoCommands::Push { content } => {
+                    datarepo_push(client, args, content).await
+                }
+                RpcDataRepoCommands::Root { height } => {
+                    let height = Height::try_from(height)?;
+                    datarepo_root_call(client, args, height).await
+                }
             },
             RpcCommands::Fevm { args, command } => match command {
                 RpcFevmCommands::Create { contract, constructor_args } => {
@@ -289,6 +296,42 @@ async fn datarepo_list_call(
     let res = client
         .inner
         .datarepo_list_call(value, gas_params, height)
+        .await?;
+
+    let json = json!({"response": res.response, "return_data": res.return_data});
+
+    print_json(&json)
+}
+
+async fn datarepo_push(
+    client: FendermintClient,
+    args: TransArgs,
+    content: Bytes,
+) -> anyhow::Result<()> {
+    broadcast_and_print(
+        client,
+        args,
+        |mut client, value, gas_params| {
+            Box::pin(async move { client.datarepo_push(content, value, gas_params).await })
+        },
+        cid_to_json,
+    )
+    .await
+}
+
+async fn datarepo_root_call(
+    client: FendermintClient,
+    args: TransArgs,
+    height: Height,
+) -> anyhow::Result<()> {
+    let mut client = TransClient::new(client, &args)?;
+    let gas_params = gas_params(&args);
+    let value = args.value;
+    let height = FvmQueryHeight::from(height.value());
+
+    let res = client
+        .inner
+        .datarepo_root_call(value, gas_params, height)
         .await?;
 
     let json = json!({"response": res.response, "return_data": res.return_data});

--- a/fendermint/rpc/Cargo.toml
+++ b/fendermint/rpc/Cargo.toml
@@ -27,6 +27,7 @@ fendermint_vm_actor_interface = { path = "../vm/actor_interface" }
 fendermint_vm_message = { path = "../vm/message" }
 
 fendermint_actor_objectstore = { path = "../actors/objectstore" }
+fendermint_actor_accumulator = { path = "../actors/accumulator" }
 
 [dev-dependencies]
 clap = { workspace = true }

--- a/fendermint/rpc/src/tx.rs
+++ b/fendermint/rpc/src/tx.rs
@@ -117,6 +117,20 @@ pub trait TxClient<M: BroadcastMode = TxCommit>: BoundClient + Send + Sync {
         Ok(res)
     }
 
+    /// Push to the accumulator in a data repo.
+    async fn datarepo_push(
+        &mut self,
+        content: Bytes,
+        value: TokenAmount,
+        gas_params: GasParams,
+    ) -> anyhow::Result<M::Response<Cid>> {
+        let mf = self.message_factory_mut();
+        let msg = mf.datarepo_push(content, value, gas_params)?;
+        let fut = self.perform(msg, decode_cid);
+        let res = fut.await?;
+        Ok(res)
+    }
+
     /// Deploy a FEVM contract.
     async fn fevm_create(
         &mut self,
@@ -204,6 +218,32 @@ pub trait CallClient: QueryClient + BoundClient {
         let response = CallResponse {
             response,
             return_data,
+        };
+
+        Ok(response)
+    }
+
+    /// Get root accumulator commitment for a data repo without including a transaction on the blockchain.
+    async fn datarepo_root_call(
+        &mut self,
+        value: TokenAmount,
+        gas_params: GasParams,
+        height: FvmQueryHeight,
+    ) -> anyhow::Result<CallResponse<Cid>> {
+        let msg = self
+            .message_factory_mut()
+            .datarepo_root(value, gas_params)?;
+
+        let response = self.call(msg, height).await?;
+        if response.value.code.is_err() {
+            return Err(anyhow!("{}", response.value.info));
+        }
+        let root =
+            decode_cid(&response.value).context("error decoding data from deliver_tx in call")?;
+
+        let response = CallResponse {
+            response,
+            return_data: Some(root),
         };
 
         Ok(response)

--- a/fendermint/vm/actor_interface/src/accumulator.rs
+++ b/fendermint/vm/actor_interface/src/accumulator.rs
@@ -1,0 +1,5 @@
+// Copyright 2022-2024 Protocol Labs
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+// TODO:(carsonfarmer): No idea what the right id here is or how to choose it
+define_id!(ACCUMULATOR { id: 102 });

--- a/fendermint/vm/actor_interface/src/lib.rs
+++ b/fendermint/vm/actor_interface/src/lib.rs
@@ -43,6 +43,7 @@ macro_rules! define_singleton {
 }
 
 pub mod account;
+pub mod accumulator;
 pub mod burntfunds;
 pub mod chainmetadata;
 pub mod cron;

--- a/fendermint/vm/actor_interface/src/objectstore.rs
+++ b/fendermint/vm/actor_interface/src/objectstore.rs
@@ -1,5 +1,5 @@
 // Copyright 2022-2024 Protocol Labs
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-// Note(sander): No idea what the right id here is or how to choose it
+// TODO:(sander): No idea what the right id here is or how to choose it
 define_id!(OBJECTSTORE { id: 101 });

--- a/fendermint/vm/interpreter/Cargo.toml
+++ b/fendermint/vm/interpreter/Cargo.toml
@@ -22,6 +22,7 @@ fendermint_rpc = { path = "../../rpc" }
 fendermint_actors = { path = "../../actors" }
 fendermint_actor_chainmetadata = { path = "../../actors/chainmetadata" }
 fendermint_actor_objectstore = { path = "../../actors/objectstore" }
+fendermint_actor_accumulator = { path = "../../actors/accumulator" }
 ipc_actors_abis = { workspace = true }
 
 ipc-api = { workspace = true }

--- a/fendermint/vm/interpreter/src/fvm/genesis.rs
+++ b/fendermint/vm/interpreter/src/fvm/genesis.rs
@@ -14,8 +14,8 @@ use fendermint_vm_actor_interface::diamond::{EthContract, EthContractMap};
 use fendermint_vm_actor_interface::eam::EthAddress;
 use fendermint_vm_actor_interface::ipc::IPC_CONTRACTS;
 use fendermint_vm_actor_interface::{
-    account, burntfunds, chainmetadata, cron, eam, init, ipc, objectstore, reward, system,
-    EMPTY_ARR,
+    account, accumulator, burntfunds, chainmetadata, cron, eam, init, ipc, objectstore, reward,
+    system, EMPTY_ARR,
 };
 use fendermint_vm_core::{chainid, Timestamp};
 use fendermint_vm_genesis::{ActorMeta, Genesis, Power, PowerScale, Validator};
@@ -259,6 +259,18 @@ where
                 None,
             )
             .context("failed to create objectstore actor")?;
+
+        // Initialize the accumulator actor.
+        let accumulator_state = fendermint_actor_accumulator::State::new(&state.store())?;
+        state
+            .create_custom_actor(
+                fendermint_actor_accumulator::ACCUMULATOR_ACTOR_NAME,
+                accumulator::ACCUMULATOR_ACTOR_ID,
+                &accumulator_state,
+                TokenAmount::zero(),
+                None,
+            )
+            .context("failed to create accumulator actor")?;
 
         // STAGE 2: Create non-builtin accounts which do not have a fixed ID.
 

--- a/scripts/run_proxy.sh
+++ b/scripts/run_proxy.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -eu
 
-fendermint proxy start --secret-key test-network/keys/alice.sk --chain-name test --broadcast-mode commit --sequence 0
+fendermint proxy start --secret-key test-network/keys/alice.sk --chain-name test --broadcast-mode async --sequence 0

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -25,7 +25,7 @@ fendermint genesis --genesis-file test-network/genesis.json add-validator --publ
 
 # Configure Tendermint
 rm -rf ~/.cometbft
-/home/sander/go/bin/cometbft init
+~/go/bin/cometbft init
 
 ## Convert the Genesis file
 mv ~/.cometbft/config/genesis.json ~/.cometbft/config/genesis.json.orig


### PR DESCRIPTION
This adds an accumulator actor, based on a merkle mountain range, or binary numeral tree. This is a minimal mmr implementation that simply accumulates any set of serializable items, in order, and stores the accumulated peaks in the state. It also tracks the total number of items or events that have been accumulated.

There is a readonly method that will "bag" the peaks, and create a single root commitment that is the full binary tree over the accumulated elements. This root cid, _or_ the root of the peaks amt could be used as a commitment on chain or elsewhere.

TODO: I'd really like to add more tests, particularly some inclusion proof tests just to ensure we are tracking the correct root etc over time.